### PR TITLE
refactor: change link, advice, deleted fetch-node

### DIFF
--- a/week1/MAKEME.md
+++ b/week1/MAKEME.md
@@ -12,7 +12,7 @@
 
 ## **1. Crash course**
 
-There is a great crash course available here: https://www.youtube.com/watch?v=2LUdnb-mls0. It introduces a lot of the concepts you will be practicing this week.
+There is a great crash course available here: https://www.youtube.com/watch?v=32M1al-Y6Ag. It introduces a lot of the concepts you will be practicing this week.
 
 ## **2. Practice the concepts**
 
@@ -54,7 +54,7 @@ Each week you'll be building a certain part of it. This week we'll get started w
 
 1. Create a JavaScript file called `server.js` (it can be any name but this is more meaningful)
 2. Initialize the Node Package Manager and create a `package.json` file by running `npm init -y`
-3. Install and load in the necessary modules for this project: they are `express` (our web server), `express-handlebars` (our templating engine) and `node-fetch` (a library to handle http requests in node)
+3. Install and load in the necessary modules for this project: `express` (our web server).
 4. As we want to use modernJS `import` statements, add the line `"type": "module"` to the `package.json` file
 5. Set up your web server using Express (creating an Express instance, listen to **port 3000**)
 6. Make a `GET` request to `/` that sends the message `hello from backend to frontend!` to the client
@@ -72,8 +72,17 @@ In this part we'll add another endpoint, with a `POST` method.
 
 Test out your work using Postman and make sure that any time you submit something in the form, it returns as a response from the server the exact words you submitted.
 
-If you are tired of constantly restarting your server, google the `nodemon` package to see if that will be useful for you!
+If you are tired of constantly restarting your server, google the `nodemon` package to see if that will be useful for you! 
 
+Also starting from **Node.js 18**, there is a built-in `--watch` flag that allows you to automatically restart your script when files change — similar to what `nodemon` does, but **without installing any extra packages**. 
+
+### Usage
+
+Run your script with the --watch flag directly in your command line or add it to your package.json scripts like this:
+
+```bash
+node --watch script.js
+```
 ## **Submit your assignment!**
 
 After you've finished your todo list it's time to show us what you got! Have a look at the following [guide](../hand-in-assignments-guide.md) to see how it's done.

--- a/week1/prep-exercises/1-web-server/package.json
+++ b/week1/prep-exercises/1-web-server/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "A simple express server",
   "main": "server.js",
+	"type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/week1/prep-exercises/1-web-server/server.js
+++ b/week1/prep-exercises/1-web-server/server.js
@@ -2,7 +2,7 @@
  * Exercise 3: Create an HTTP web server
  */
 
-const http = require('http');
+import http from "node:http";
 
 //create a server
 let server = http.createServer(function (req, res) {

--- a/week2/MAKEME.md
+++ b/week2/MAKEME.md
@@ -41,8 +41,7 @@ Our external API that we're going to work with is the [Open Weather Map API](htt
 
 #### 3.1.2 Fetch it from our API
 
-1. Remove the response from the `POST` route from last week, we'll rewrite it later
-2. Inside of the the `POST` route, bring in `node-fetch` and pass the value of the API endpoint: `https://api.openweathermap.org/data/2.5/weather`. For it to work we first have to import the keys, like so:
+1. Inside the `POST` route, fetch data from the OpenWeatherMap API endpoint `https://api.openweathermap.org/data/2.5/weather` using the built-in fetch function:
 
 ```js
 import keys from "./sources/keys.js";


### PR DESCRIPTION
https://www.youtube.com/watch?v=32M1al-Y6Ag - Video with modern Node js (1 year ago)

`express-handlebars` - now not really popular. We have React instead even for emails. + We don't need for exercise handlebars.

Node-fetch now build-in function in Node.js. Due to: Node.js 18+: Built-in fetch available globally, just like in browsers.

--watch flag build-in instead of nodemon.

